### PR TITLE
feat: add env example file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,16 @@
+# Clerk for auth
 CLERK_PUBLISHABLE_KEY=your_clerk_publishable_key
 CLERK_SECRET_KEY=your_clerk_secret_key
+CLERK_ISSUER_URL=your_clerk_issuer_url
+
+# OpenAI for image gen
 OPENAI_API_KEY=your_openai_api_key
+
+# Polar
+POLAR_ACCESS_TOKEN=your_polar_access_token
+FRONTEND_URL=your_frontend_url
+POLAR_WEBHOOK_SECRET=your_polar_webhook_secret
+POLAR_ORGANIZATION_ID=your_polar_organization_id
 
 # Deployment used by `npx convex dev`
 CONVEX_DEPLOYMENT=anonymous:anonymous-paperbag.fyi

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+CLERK_PUBLISHABLE_KEY=your_clerk_publishable_key
+CLERK_SECRET_KEY=your_clerk_secret_key
+OPENAI_API_KEY=your_openai_api_key
+
+# Deployment used by `npx convex dev`
+CONVEX_DEPLOYMENT=anonymous:anonymous-paperbag.fyi
+
+VITE_CONVEX_URL=http://127.0.0.1:3210


### PR DESCRIPTION
Just a small change to add example env file as per your README, so that users can actually run `cp .env.example .env.local`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Added an example environment configuration file with placeholders for authentication, API access, and backend connectivity settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->